### PR TITLE
Add dotenv support and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Only required for running the script standalone
+API_KEY=api_key_here

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # ewn-box-opener
+
 Box Opener client for mining EWN tokens.
+
+## How to run
+
+There are two ways to run the the Box Opener:
+
+### 1. Docker (recommended)
+
+The easiest way to run the Box Opener is to use Docker. [Find out more on how to run with Docker](https://docs.erwin.lol/docs/box-openers/box-opener-node).
+
+### 2. Standalone (advanced)
+
+Another way to run the Box Opener is to run the Python script standalone. Docs will follow.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.32.3
 pybip39==0.1.0
+python-dotenv==1.0.1

--- a/run_box_opener.py
+++ b/run_box_opener.py
@@ -2,8 +2,10 @@ import logging
 import time
 import os
 import requests
-
 from pybip39 import Mnemonic
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 logging.basicConfig(


### PR DESCRIPTION
- Added `python-dotenv` package to manage environment variables from a `.env` file.
- Updated `requirements.txt` to include `python-dotenv`.
- Implemented `load_dotenv()` in the script to load environment variables.
- Created a `.env.example` file as a template for environment variable setup.
- Updated README to demonstrate two methods for running the box opener, providing clearer instructions for repo visitors (will add to docs soon).