### PR TITLE
Enhance Docker workflow for multi-architecture support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,6 +45,10 @@ jobs:
         with:
           cosign-release: 'v2.2.4'
 
+      # Set up QEMU for ARM emulation
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
@@ -77,6 +81,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -96,3 +101,26 @@ jobs:
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+
+      - name: Determine host architecture
+        id: host_arch
+        run: |
+          HOST_ARCH=$(uname -m)
+          echo "HOST_ARCH=$HOST_ARCH" >> $GITHUB_OUTPUT
+
+      - name: Run container
+        run: |
+          if [ "${{ steps.host_arch.outputs.HOST_ARCH }}" = "x86_64" ]; then
+            PLATFORM="linux/amd64"
+          else
+            PLATFORM="linux/arm64"
+          fi
+          docker run -d --name ewn-box-opener \
+            --platform $PLATFORM \
+            --restart unless-stopped \
+            -e API_KEY=${{ secrets.API_KEY }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+      # Check container status
+      - name: Check container status
+        run: docker ps -a


### PR DESCRIPTION
This update improves our Docker workflow by adding support for both AMD64 and ARM64 architectures. Here’s what’s changed:

- Set up QEMU to enable ARM emulation.
- Configured Docker Buildx to build images for multiple platforms.
- Added logic to automatically determine the host architecture and select the appropriate platform when running the container.

These changes will make it easier to build and run our images on different systems, ensuring better compatibility across environments. 

Usage notes:
1. Basic run command (will show a warning but runs correctly): docker run -it -e API_KEY=<your_api_key> ghcr.io/erwin-schrodinger-token/ewn-box-opener:latest

2. To suppress the platform mismatch warning, use: docker run -it --platform linux/amd64 -e API_KEY=<your_api_key> ghcr.io/erwin-schrodinger-token/ewn-box-opener:latest

The warning message "The requested image's platform (linux/amd64) does not match  the detected host platform (linux/arm64/v8)" can be safely ignored when running  without the --platform flag, as QEMU will handle the emulation automatically.