### PR TITLE
Update Documentation for Multi-Architecture Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The easiest way to run the Box Opener is to use Docker. [Find out more on how to
 
 ### 2. Standalone (advanced)
 
-Another way to run the Box Opener is to run the Python script standalone. Docs will follow.
+## Another way to run the Box Opener is to run the Python script standalone. Docs will follow.
 =======
 - linux/amd64 (64-bit x86 systems)
 - linux/arm64 (64-bit ARM systems)

--- a/README.md
+++ b/README.md
@@ -13,3 +13,43 @@ The easiest way to run the Box Opener is to use Docker. [Find out more on how to
 ### 2. Standalone (advanced)
 
 Another way to run the Box Opener is to run the Python script standalone. Docs will follow.
+=======
+- linux/amd64 (64-bit x86 systems)
+- linux/arm64 (64-bit ARM systems)
+- linux/arm/v7 (32-bit ARM systems, like older Raspberry Pi models)
+
+This means you can run the Box Opener on a variety of devices, from standard PCs to Raspberry Pis and other ARM-based systems.
+
+### Usage Notes
+
+When running the Box Opener with Docker, use the following commands:
+
+- Standard run command (may show a warning on non-AMD64 systems, but will run correctly):
+
+    ```bash
+    docker run -it -e API_KEY=<your_api_key> ghcr.io/erwin-schrodinger-token/ewn-box-opener:latest
+    ```
+
+- To suppress the platform mismatch warning, explicitly specify the platform:
+ 
+    ```bash
+    docker run -it --platform linux/amd64 -e API_KEY=<your_api_key> ghcr.io/erwin-schrodinger-token/ewn-box-opener:latest
+    ```
+
+- To run the container in the background, add the -d flag:
+ 
+    ```bash
+    docker run -d -e API_KEY=<your_api_key> ghcr.io/erwin-schrodinger-token/ewn-box-opener:latest
+    ```
+
+- To run in the background and suppress platform mismatch warning:
+ 
+    ```bash
+    docker run -d --platform linux/amd64 -e API_KEY=<your_api_key> ghcr.io/erwin-schrodinger-token/ewn-box-opener:latest
+    ```
+
+Replace `linux/amd64` with `linux/arm64` or `linux/arm/v7` as appropriate for your system.
+
+**Note:** The warning message "The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8)" can be safely ignored when running without the --platform flag, as QEMU will handle the emulation automatically.
+
+These enhancements ensure that the Box Opener can run efficiently on a wide range of hardware, from powerful servers to small, energy-efficient ARM devices.


### PR DESCRIPTION
This pull request enhances the README.md by adding detailed documentation on multi-architecture support for the Box Opener. 
Key updates include:
- Integration of QEMU for ARM emulation.
- Configuration of Docker Buildx to support multiple platforms (```linux/amd64```, ```linux/arm64```, ```linux/arm/v7```).
- Usage notes for running the Box Opener on various architectures, including handling platform mismatch warnings.

These changes aim to improve user understanding and accessibility across different hardware platforms.
