### PR TITLE
More cleanly handle 500 and 530 errors and all other uncaught http codes

### DIFF
--- a/run_box_opener.py
+++ b/run_box_opener.py
@@ -51,6 +51,11 @@ def submit_guesses():
             f"❌ Guesses rejected ({resp.status_code}): {resp.text}"
         )
         return False
+    if resp.status_code == 500:
+        logging.info(
+            f"❌ Guesses rejected ({resp.status_code}): Internal Server Error"
+        )
+        return False
     if resp.status_code == 502:
         logging.info(
             f"❌ Guesses rejected ({resp.status_code}): Bad Gateway"

--- a/run_box_opener.py
+++ b/run_box_opener.py
@@ -68,7 +68,7 @@ def submit_guesses():
         return False
     else:
         logging.info(
-            f"❌ Guesses rejected ({resp.status_code}): {resp.text}"
+            f"❌ Guesses rejected ({resp.status_code}): Unspecified Error"
         )
         return True
 

--- a/run_box_opener.py
+++ b/run_box_opener.py
@@ -61,6 +61,11 @@ def submit_guesses():
             f"❌ Guesses rejected ({resp.status_code}): Bad Gateway"
         )
         return False
+    if resp.status_code == 530:
+        logging.info(
+            f"❌ Guesses rejected ({resp.status_code}): Argo Tunnel Error"
+        )
+        return False
     else:
         logging.info(
             f"❌ Guesses rejected ({resp.status_code}): {resp.text}"


### PR DESCRIPTION
Show a 500 error as a generic Internal Server Error, and a 530 error as a generic Argo Tunnel Error, instead of spitting out the HTML. Also remove `{resp.text}` to avoid outputting the HTML of the error page for an uncaught http code into the logs.