### PR TITLE
Better handling of error 401

### DIFF
--- a/run_box_opener.py
+++ b/run_box_opener.py
@@ -46,6 +46,11 @@ def submit_guesses():
     if resp.status_code == 202:
         logging.info("✅ Guesses accepted")
         return False
+    if resp.status_code == 401:
+        logging.info(
+            f"❌ Guesses rejected ({resp.status_code}): {resp.text}"
+        )
+        return False
     if resp.status_code == 404:
         logging.info(
             f"❌ Guesses rejected ({resp.status_code}): {resp.text}"


### PR DESCRIPTION
Since v1.0.8, error 401 always shows 'Unspecified Error'. Although there could be some other reasons for that HTTP error code, like Cloudflare not liking the client, the most common reasons would be an invalid API key or the box opener not being charged. As such, I'm proposing reverting to printing `{resp.text}`, even though that may risk HTML output in the logs.