### PR TITLE
Enabled rate limiting for error 429

### DIFF
--- a/run_box_opener.py
+++ b/run_box_opener.py
@@ -60,6 +60,7 @@ def submit_guesses():
         logging.info(
             f"❌ Guesses rejected ({resp.status_code}): {resp.text}"
         )
+        return True
     elif resp.status_code == 500:
         logging.info(
             f"❌ Guesses rejected ({resp.status_code}): Internal Server Error"


### PR DESCRIPTION
Enabled rate limiting for error 429 - "Guess Rate Limit Hit"
I believe this error was supposed to extend the sleep time, but instead it returned "False"